### PR TITLE
Erweitere Baustellen Typen in der OpenAPI Spezifikation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -353,6 +353,7 @@ components:
         - CLOSURE
         - CLOSURE_ENTRY_EXIT
         - STRONG_ELECTRIC_CHARGING_STATION
+        - SHORT_TERM_ROADWORKS
 
     LorryParkingFeatureIcon:
       type: object


### PR DESCRIPTION
Einfüge einen weiteren "display_type" für die Baustellen (SHORT_TERM_ROADWORKS)

Eine Beispielantwort hier angehängt
[roadworks_a3_22082021_2331.json.zip](https://github.com/bundesAPI/autobahn-api/files/7028201/roadworks_a3_22082021_2331.json.zip)

