### PR TITLE
changed quotation marks of regex

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -348,7 +348,7 @@ components:
 
     RoadId:
       type: string
-      pattern: "A[1-9]([0-9]{1,3})?(\/A[1-9]{1,3})?"
+      pattern: 'A[1-9]([0-9]{1,3})?(\/A[1-9]{1,3})?'
       example: "A1"
 
     Extent:


### PR DESCRIPTION
The client [generator](https://github.com/OpenAPITools/openapi-generator) fails with the following message:

```
found unknown escape character /(47)
 in 'string', line 351, column 38:
     ...  pattern: "A[1-9]([0-9]{1,3})?(\/A[1-9]{1,3})?"

```

Changing from double quotes to single quotes fixed it for me.