### PR TITLE
Weitere API-Endpunkte

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,11 +5,11 @@ info:
   description: |
     Was passiert auf Deutschlands Bundesstraßen? API für aktuelle Verwaltungsdaten zu Baustellen, Staus und Ladestationen. Außerdem Zugang zu Verkehrsüberwachungskameras und vielen weiteren Datensätzen.
 servers:
-  - url: https://verkehr.autobahn.de/o/autobahn
+  - url: https://verkehr.autobahn.de/o
 
 paths:
 
-  /:
+  /autobahn/:
     get:
       operationId: list-autobahnen
       summary: Liste verfügbarer Autobahnen
@@ -22,7 +22,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Roads"
 
-  /{roadId}/services/roadworks:
+  /autobahn/{roadId}/services/roadworks:
     get:
       operationId: list-roadworks
       summary: Liste aktueller Baustellen
@@ -47,7 +47,7 @@ paths:
         "404":
           description: Not found.
 
-  /details/roadworks/{roadworkId}:
+  /autobahn/details/roadworks/{roadworkId}:
     get:
       operationId: get-roadwork
       summary: Details einer Baustelle
@@ -74,7 +74,7 @@ paths:
         "404":
           description: Not found.
 
-  /{roadId}/services/webcam:
+  /autobahn/{roadId}/services/webcam:
     get:
       operationId: list-webcams
       summary: Liste verfügbarer Webcams
@@ -100,7 +100,7 @@ paths:
           description: Not found.
 
   # https://verkehr.autobahn.de/o/autobahn/details/webcam/%5BID%5D
-  /details/webcam/{webcamId}:
+  /autobahn/details/webcam/{webcamId}:
     get:
       operationId: get-webcam
       summary: Details einer Webcam
@@ -127,7 +127,7 @@ paths:
         "404":
           description: Not found.
 
-  /{roadId}/services/parking_lorry:
+  /autobahn/{roadId}/services/parking_lorry:
     get:
       operationId: list-parking-lorries
       summary: Liste verfügbarer Rastplätze
@@ -152,7 +152,7 @@ paths:
         "404":
           description: Not found.
 
-  /details/parking_lorry/{lorryId}:
+  /autobahn/details/parking_lorry/{lorryId}:
     get:
       operationId: get-parking-lorry
       summary: Details eines Rastplatzes
@@ -179,7 +179,7 @@ paths:
         "404":
           description: Not found.
 
-  /{roadId}/services/warning:
+  /autobahn/{roadId}/services/warning:
     get:
       operationId: list-warnings
       summary: Liste aktueller Verkehrsmeldungen
@@ -204,7 +204,7 @@ paths:
         "404":
           description: Not found.
 
-  /details/warning/{warningId}:
+  /autobahn/details/warning/{warningId}:
     get:
       operationId: get-warning
       summary: Details zu einer Verkehrsmeldung
@@ -231,7 +231,7 @@ paths:
         "404":
           description: Not found.
 
-  /{roadId}/services/closure:
+  /autobahn/{roadId}/services/closure:
     get:
       operationId: list-closures
       summary: Liste aktueller Sperrungen
@@ -256,7 +256,7 @@ paths:
         "404":
           description: Not found.
 
-  /details/closure/{closureId}:
+  /autobahn/details/closure/{closureId}:
     get:
       operationId: get-closure
       summary: Details zu einer Sperrung
@@ -283,7 +283,7 @@ paths:
         "404":
           description: Not found.
 
-  /{roadId}/services/electric_charging_station:
+  /autobahn/{roadId}/services/electric_charging_station:
     get:
       operationId: list-charging-stations
       summary: Liste aktueller Ladestationen
@@ -308,7 +308,7 @@ paths:
         "404":
           description: Not found.
 
-  /details/electric_charging_station/{stationId}:
+  /autobahn/details/electric_charging_station/{stationId}:
     get:
       operationId: get-charging-station
       summary: Details zu einer Ladestation

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -161,6 +161,58 @@ paths:
               schema:
                 $ref: "#/components/schemas/RoadsAffected"
 
+  /autobahn/{roadId}/services/parking:
+    get:
+      operationId: list-parkings
+      summary: Liste verfügbarer Rastplätze
+      description: Gibt eine Liste der Rastplätze zu einer Autobahn zurück.
+      parameters:
+        - name: roadId
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/RoadId"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ParkingLorries"
+        "204":
+          description: Not found.
+        "400":
+          description: Internal server error.
+        "404":
+          description: Not found.
+
+  /autobahn/details/parking/{parkingId}:
+    get:
+      operationId: get-parking
+      summary: Details eines Rastplatzes
+      description: Gibt Details eines konkreten Rastplatzes zurück.
+      parameters:
+        - name: parkingId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: byte
+            example: "UEFSS0lOR19fbWRtLmxvcnJ5LnBhcmtpbmdfX0RFLVNILTAwMTEwOA=="
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ParkingLorry"
+        "204":
+          description: Not found.
+        "400":
+          description: Internal server error.
+        "404":
+          description: Not found.
+
   /services/parking_lorry:
     get:
       operationId: list-parking-lorry-all

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -22,6 +22,23 @@ paths:
               schema:
                 $ref: "#/components/schemas/Roads"
 
+  /services/roadworks:
+    get:
+      operationId: list-roadworks-all
+      summary: Liste verfügbarer Autobahnen mit aktuellen Baustellen
+      description: Gibt eine Liste der verfügbaren Autobahnen mit aktuellen Baustellen zurück.
+      parameters:
+        - name: roadId
+          in: path
+          required: true
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RoadsAffected"
+
   /autobahn/{roadId}/services/roadworks:
     get:
       operationId: list-roadworks
@@ -127,11 +144,45 @@ paths:
         "404":
           description: Not found.
 
+  /services/parking:
+    get:
+      operationId: list-parking-all
+      summary: Liste verfügbarer Autobahnen mit Rastplätzen
+      description: Gibt eine Liste der verfügbaren Autobahnen mit Rastplätzen zurück.
+      parameters:
+        - name: roadId
+          in: path
+          required: true
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RoadsAffected"
+
+  /services/parking_lorry:
+    get:
+      operationId: list-parking-lorry-all
+      summary: Liste verfügbarer Autobahnen mit Lkw-Rastplätzen
+      description: Gibt eine Liste der verfügbaren Autobahnen mit Lkw-Rastplätzen zurück.
+      parameters:
+        - name: roadId
+          in: path
+          required: true
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RoadsAffected"
+
   /autobahn/{roadId}/services/parking_lorry:
     get:
       operationId: list-parking-lorries
-      summary: Liste verfügbarer Rastplätze
-      description: Gibt eine Liste der Rastplätze zu einer Autobahn zurück.
+      summary: Liste verfügbarer Lkw-Rastplätze
+      description: Gibt eine Liste der Lkw-Rastplätze zu einer Autobahn zurück.
       parameters:
         - name: roadId
           in: path
@@ -155,8 +206,8 @@ paths:
   /autobahn/details/parking_lorry/{lorryId}:
     get:
       operationId: get-parking-lorry
-      summary: Details eines Rastplatzes
-      description: Gibt Details eines konkreten Rastplatzes zurück.
+      summary: Details eines Lkw-Rastplatzes
+      description: Gibt Details eines konkreten Lkw-Rastplatzes zurück.
       parameters:
         - name: lorryId
           in: path
@@ -178,6 +229,23 @@ paths:
           description: Internal server error.
         "404":
           description: Not found.
+
+  /services/warning:
+    get:
+      operationId: list-warning-all
+      summary: Liste verfügbarer Autobahnen mit Verkehrsmeldungen
+      description: Gibt eine Liste der verfügbaren Autobahnen mit Verkehrsmeldungen zurück.
+      parameters:
+        - name: roadId
+          in: path
+          required: true
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RoadsAffected"
 
   /autobahn/{roadId}/services/warning:
     get:
@@ -231,6 +299,23 @@ paths:
         "404":
           description: Not found.
 
+  /services/closure:
+    get:
+      operationId: list-closures-all
+      summary: Liste verfügbarer Autobahnen mit aktuellen Sperrungen
+      description: Gibt eine Liste der verfügbaren Autobahnen mit aktuellen Sperrungen zurück.
+      parameters:
+        - name: roadId
+          in: path
+          required: true
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RoadsAffected"
+
   /autobahn/{roadId}/services/closure:
     get:
       operationId: list-closures
@@ -282,6 +367,23 @@ paths:
           description: Internal server error.
         "404":
           description: Not found.
+
+  /services/electric_charging_station:
+    get:
+      operationId: list-charging-stations-all
+      summary: Liste verfügbarer Autobahnen mit Ladestationen
+      description: Gibt eine Liste der verfügbaren Autobahnen mit Ladestationen zurück.
+      parameters:
+        - name: roadId
+          in: path
+          required: true
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RoadsAffected"
 
   /autobahn/{roadId}/services/electric_charging_station:
     get:
@@ -350,6 +452,26 @@ components:
       type: string
       pattern: 'A[1-9]([0-9]{1,3})?(\/A[1-9]{1,3})?'
       example: "A1"
+
+    RoadsAffected:
+      type: object
+      properties:
+        roadCounter:
+          type: array
+          items:
+            $ref: '#/components/schemas/RoadCounter'
+
+    RoadCounter:
+      type: object
+      example: {
+        "road": "A1",
+        "counter": "99"
+      }
+      properties:
+        road:
+          $ref: '#/components/schemas/RoadId'
+        counter:
+          type: number
 
     Extent:
       type: string


### PR DESCRIPTION
Wie in #20 beschrieben, außerdem `/parking` für Pkw-Rastplätze (`/parking_lorry` ist auf Rastplätze mit Lkw-Stellplätzen beschränkt).

Hierzu musste `/autobahn` aus der Basis-URL in die bereits dokumentierten URLs verschoben werden.

Syntaxprüfung habe ich keine durchgeführt – wenn etwas nicht passt, bitte melden.