### PR TITLE
roadId ist nicht auf Autobahnen beschränkt

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -351,7 +351,13 @@ components:
       pattern: '[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?(\/[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?)?'
       description: |
         Kann jede gültige Straßenbezeichnung sein (nicht auf Autobahnen beschränkt). Die Gültigkeit wird nicht überprüft: Abfragen mit nicht existierenden Straßenbezeichnungen liefern einen leeren Datensatz zurück.
-      example: "A1"
+      examples:
+        autobahn:
+          value: "A1"
+          summary: Autobahnnummer
+        bundesstrasse:
+          value: "B2"
+          summary: Bundesstraßennummer
 
     Extent:
       type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -351,13 +351,7 @@ components:
       pattern: '[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?(\/[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?)?'
       description: |
         Kann jede gültige Straßenbezeichnung sein (nicht auf Autobahnen beschränkt). Die Gültigkeit wird nicht überprüft: Abfragen mit nicht existierenden Straßenbezeichnungen liefern einen leeren Datensatz zurück. Die Schreibweise kann von der sonst üblichen Form abweichen (z.B. S1234 statt St1234 für Staatsstraßen).
-      examples:
-        autobahn:
-          value: "A1"
-          summary: Autobahnnummer
-        bundesstrasse:
-          value: "B2"
-          summary: Bundesstraßennummer
+      example: "A1"
 
     Extent:
       type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -348,7 +348,9 @@ components:
 
     RoadId:
       type: string
-      pattern: 'A[1-9]([0-9]{1,3})?(\/A[1-9]{1,3})?'
+      pattern: '[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?(\/[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?)?'
+      description: |
+        Kann jede gültige Straßenbezeichnung sein (nicht auf Autobahnen beschränkt). Die Gültigkeit wird nicht überprüft: Abfragen mit nicht existierenden Straßenbezeichnungen liefern einen leeren Datensatz zurück.
       example: "A1"
 
     Extent:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -350,7 +350,7 @@ components:
       type: string
       pattern: '[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?(\/[A-Z][A-Za-z]*[1-9]([0-9]{1,3})?)?'
       description: |
-        Kann jede gültige Straßenbezeichnung sein (nicht auf Autobahnen beschränkt). Die Gültigkeit wird nicht überprüft: Abfragen mit nicht existierenden Straßenbezeichnungen liefern einen leeren Datensatz zurück.
+        Kann jede gültige Straßenbezeichnung sein (nicht auf Autobahnen beschränkt). Die Gültigkeit wird nicht überprüft: Abfragen mit nicht existierenden Straßenbezeichnungen liefern einen leeren Datensatz zurück. Die Schreibweise kann von der sonst üblichen Form abweichen (z.B. S1234 statt St1234 für Staatsstraßen).
       examples:
         autobahn:
           value: "A1"


### PR DESCRIPTION
Siehe #19.